### PR TITLE
[DO NOT MERGE!] Proposed packaging for opam releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Default behaviour, for if core.autocrlf isn't set
+* text=auto
+
+# Shell scripts need Unix line endings
+scripts/gen_install.sh text eol=lf
+
+# Files not needed in the archive
+.gitattributes export-ignore
+Makefile.am export-ignore
+Makefile.in export-ignore
+aclocal.m4 export-ignore
+build-aux export-ignore
+config.h.in export-ignore
+configure export-ignore
+configure.ac export-ignore
+m4 export-ignore
+scripts export-ignore
+src/libgcc/* export-ignore
+src/version.rc export-ignore
+tests export-ignore
+tests_pthread export-ignore
+winpthreads.opam export-ignore

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,21 @@
+# winpthreads opam packaging support
+
+winpthreads is packaged in opam in the same way as flexdll. A tarball is
+downloaded which "installs" the required sources to `share/winpthreads` in the
+switch, and this directory is then passed to OCaml's `configure` script by the
+compiler opam packages.
+
+Releases are versioned using the date of the commit and an epoch number,
+e.g. 20240209-1 for d635af4d9. `scripts/gen_install.sh` generates an opam
+`.install` file.
+
+Releasing winpthreads involves creating a branch which merges an upstream commit
+with this branch and then committing the generated winpthreads.install. Taking
+d635af4d9 again:
+
+```console
+$ git checkout -b 20240902-1 d635af4d9
+$ git merge --allow-unrelated-histories --no-commit opam
+$ scripts/gen_install.sh > winpthreads.install
+$ git add winpthreads.install
+$ git commit -m 'opam package for 20240902-1'

--- a/scripts/gen_install.sh
+++ b/scripts/gen_install.sh
@@ -1,0 +1,9 @@
+#/bin/sh
+
+echo 'share: ['
+
+for file in $(ls include/*.h src/*.h src/*.c | sort | sed -e 's|/|\\\\|g'); do
+  echo "  \"$file\" {\"$file\"}"
+done
+
+echo ']'

--- a/winpthreads.install
+++ b/winpthreads.install
@@ -1,0 +1,30 @@
+share: [
+  "include\\pthread.h" {"include\\pthread.h"}
+  "include\\pthread_compat.h" {"include\\pthread_compat.h"}
+  "include\\pthread_signal.h" {"include\\pthread_signal.h"}
+  "include\\pthread_time.h" {"include\\pthread_time.h"}
+  "include\\pthread_unistd.h" {"include\\pthread_unistd.h"}
+  "include\\sched.h" {"include\\sched.h"}
+  "include\\semaphore.h" {"include\\semaphore.h"}
+  "src\\barrier.c" {"src\\barrier.c"}
+  "src\\barrier.h" {"src\\barrier.h"}
+  "src\\clock.c" {"src\\clock.c"}
+  "src\\cond.c" {"src\\cond.c"}
+  "src\\cond.h" {"src\\cond.h"}
+  "src\\misc.c" {"src\\misc.c"}
+  "src\\misc.h" {"src\\misc.h"}
+  "src\\mutex.c" {"src\\mutex.c"}
+  "src\\nanosleep.c" {"src\\nanosleep.c"}
+  "src\\ref.c" {"src\\ref.c"}
+  "src\\ref.h" {"src\\ref.h"}
+  "src\\rwlock.c" {"src\\rwlock.c"}
+  "src\\rwlock.h" {"src\\rwlock.h"}
+  "src\\sched.c" {"src\\sched.c"}
+  "src\\sem.c" {"src\\sem.c"}
+  "src\\sem.h" {"src\\sem.h"}
+  "src\\spinlock.c" {"src\\spinlock.c"}
+  "src\\thread.c" {"src\\thread.c"}
+  "src\\thread.h" {"src\\thread.h"}
+  "src\\winpthread_internal.h" {"src\\winpthread_internal.h"}
+  "src\\wpth_ver.h" {"src\\wpth_ver.h"}
+]

--- a/winpthreads.opam
+++ b/winpthreads.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+authors: "mingw-w64 project"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/winpthreads/issues"
+homepage: "https://github.com/ocaml/winpthreads#readme"
+license: "BSD-3-Clause AND MIT"
+synopsis: "Posix Threads for Windows (winpthreads) Sources"
+description: "Source package for winpthreads. Installs the required files for
+compiling winpthreads as part of an MSVC OCaml build."


### PR DESCRIPTION
On [my fork](https://github.com/dra27/winpthreads) I have two branches 20240902-1 and opam which demonstrate a proposed means of producing tarballs automatically from GitHub commits.

This PR isn't intended to be merged; assuming we're happy with this I will push these two branches to this repo.

The idea is to create a package which when installed in opam provides the files needed for winpthreads when configuring OCaml (the packaging for Windows handles flexdll in the same way).

The tarball produced by this branch contains:
```
C:\Devel>tar tf 20240902-1.tar.gz
winpthreads-20240902-1/
winpthreads-20240902-1/COPYING
winpthreads-20240902-1/README
winpthreads-20240902-1/include/
winpthreads-20240902-1/include/pthread.h
winpthreads-20240902-1/include/pthread_compat.h
winpthreads-20240902-1/include/pthread_signal.h
winpthreads-20240902-1/include/pthread_time.h
winpthreads-20240902-1/include/pthread_unistd.h
winpthreads-20240902-1/include/sched.h
winpthreads-20240902-1/include/semaphore.h
winpthreads-20240902-1/src/
winpthreads-20240902-1/src/barrier.c
winpthreads-20240902-1/src/barrier.h
winpthreads-20240902-1/src/clock.c
winpthreads-20240902-1/src/cond.c
winpthreads-20240902-1/src/cond.h
winpthreads-20240902-1/src/libgcc/
winpthreads-20240902-1/src/misc.c
winpthreads-20240902-1/src/misc.h
winpthreads-20240902-1/src/mutex.c
winpthreads-20240902-1/src/nanosleep.c
winpthreads-20240902-1/src/ref.c
winpthreads-20240902-1/src/ref.h
winpthreads-20240902-1/src/rwlock.c
winpthreads-20240902-1/src/rwlock.h
winpthreads-20240902-1/src/sched.c
winpthreads-20240902-1/src/sem.c
winpthreads-20240902-1/src/sem.h
winpthreads-20240902-1/src/spinlock.c
winpthreads-20240902-1/src/thread.c
winpthreads-20240902-1/src/thread.h
winpthreads-20240902-1/src/winpthread_internal.h
winpthreads-20240902-1/src/wpth_ver.h
winpthreads-20240902-1/winpthreads.install
```